### PR TITLE
Fix assistant usage polling to capture token usage

### DIFF
--- a/Model/AssistantsGPTAPI.php
+++ b/Model/AssistantsGPTAPI.php
@@ -126,9 +126,16 @@ class Migachat_Model_AssistantsGPTAPI
         return $this->request("POST", "/threads/{$threadId}/runs", $payload);
     }
 
-    public function getRunStatus($threadId, $runId)
+    public function getRunStatus($threadId, $runId, $params = [])
     {
-        return $this->request("GET", "/threads/{$threadId}/runs/{$runId}");
+        $endpoint = "/threads/{$threadId}/runs/{$runId}";
+
+        if (! empty($params)) {
+            $query    = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+            $endpoint .= "?{$query}";
+        }
+
+        return $this->request("GET", $endpoint);
     }
 
     public function getThreadMessages($threadId, $params = [])

--- a/controllers/Mobile/ViewController.php
+++ b/controllers/Mobile/ViewController.php
@@ -1278,7 +1278,7 @@ class Migachat_Mobile_ViewController extends Application_Controller_Mobile_Defau
                                 sleep(2);
 
                                 try {
-                                    $status = $openai->getRunStatus($thread_id, $run_id);
+                                    $status = $openai->getRunStatus($thread_id, $run_id, ['include' => ['usage']]);
                                 } catch (Exception $exception) {
                                     $this->logMobileAssistantException($exception, 'getRunStatus');
                                     $payload = $this->finalizeMobileAssistantFailure(

--- a/controllers/Public/BridgeapiController.php
+++ b/controllers/Public/BridgeapiController.php
@@ -2340,7 +2340,7 @@ class Migachat_Public_BridgeapiController extends Migachat_Controller_Default
             usleep(600000);
 
             try {
-                $status = $openai->getRunStatus($threadId, $runId);
+                $status = $openai->getRunStatus($threadId, $runId, ['include' => ['usage']]);
             } catch (Exception $exception) {
                 $this->logAssistantException($exception, 'getRunStatus');
                 return $this->assistantFailurePayload($this->mapAssistantApiErrorCodeToMessage(null));


### PR DESCRIPTION
## Summary
- allow the Assistants API client to pass optional query parameters when retrieving a run status
- request usage details while polling assistant runs in both public and mobile controllers

## Testing
- php -l Model/AssistantsGPTAPI.php
- php -l controllers/Public/BridgeapiController.php
- php -l controllers/Mobile/ViewController.php

------
https://chatgpt.com/codex/tasks/task_e_68dc15446278832a9afb924d574b6353