### PR TITLE
Add webhook log summaries to campaign listings

### DIFF
--- a/controllers/ApplicationController.php
+++ b/controllers/ApplicationController.php
@@ -40,6 +40,14 @@ class Aerosalloyalty_ApplicationController extends Application_Controller_Defaul
                 $data['last_operation_at'] = null;
             }
 
+            if (!array_key_exists('webhook_logs', $data)) {
+                $data['webhook_logs'] = null;
+            }
+
+            if (!array_key_exists('webhook_log_summary', $data)) {
+                $data['webhook_log_summary'] = null;
+            }
+
             return $data;
         }, $rows);
     }
@@ -74,6 +82,7 @@ class Aerosalloyalty_ApplicationController extends Application_Controller_Defaul
             $settings = (new Aerosalloyalty_Model_Settings())->findAll(['value_id' => $value_id])->toArray();
             $types    = (new Aerosalloyalty_Model_CampaignType())->findAll(['value_id' => $value_id])->toArray();
             $campaigns = $this->_formatCampaignRows($this->_fetchCampaignRows($value_id));
+            $campaigns = $this->_attachLatestWebhookLogs($value_id, $campaigns);
             return $this->_sendJson([
                 'success' => 1,
                 'settings' => $settings ? $settings[0] : [],
@@ -226,18 +235,261 @@ class Aerosalloyalty_ApplicationController extends Application_Controller_Defaul
 
             $card_number = trim($this->getRequest()->getParam('card_number', ''));
 
+            $campaigns = $this->_formatCampaignRows(
+                $this->_fetchCampaignRows(
+                    $value_id,
+                    $card_number !== '' ? $card_number : null
+                )
+            );
+            $campaigns = $this->_attachLatestWebhookLogs($value_id, $campaigns);
+
             return $this->_sendJson([
                 'success' => 1,
-                'campaigns' => $this->_formatCampaignRows(
-                    $this->_fetchCampaignRows(
-                        $value_id,
-                        $card_number !== '' ? $card_number : null
-                    )
-                )
+                'campaigns' => $campaigns
             ]);
         } catch (Exception $e) {
             return $this->_sendJson(['error' => 1, 'message' => $e->getMessage()]);
         }
+    }
+
+    /**
+     * Enrich campaign payload with latest webhook log metadata.
+     *
+     * @param int   $valueId
+     * @param array $campaigns
+     * @return array
+     */
+    protected function _attachLatestWebhookLogs($valueId, array $campaigns)
+    {
+        if (empty($campaigns)) {
+            return $campaigns;
+        }
+
+        $logs = $this->_fetchLatestWebhookLogs($valueId, $campaigns);
+
+        foreach ($campaigns as &$campaign) {
+            $uid = isset($campaign['campaign_uid']) ? (string)$campaign['campaign_uid'] : '';
+            if ($uid !== '' && isset($logs[$uid])) {
+                $campaign['webhook_logs'] = [
+                    'latest' => $logs[$uid]['latest'] ?? null,
+                    'inbound' => $logs[$uid]['inbound'] ?? null,
+                    'outbound' => $logs[$uid]['outbound'] ?? null,
+                ];
+                $campaign['webhook_log_summary'] = $logs[$uid]['summary'] ?? null;
+            } else {
+                $campaign['webhook_logs'] = null;
+                $campaign['webhook_log_summary'] = null;
+            }
+        }
+        unset($campaign);
+
+        return $campaigns;
+    }
+
+    /**
+     * Retrieve most recent webhook logs for given campaigns.
+     *
+     * @param int   $valueId
+     * @param array $campaigns
+     * @return array
+     */
+    protected function _fetchLatestWebhookLogs($valueId, array $campaigns)
+    {
+        $uids = [];
+        foreach ($campaigns as $campaign) {
+            $uid = isset($campaign['campaign_uid']) ? (string)$campaign['campaign_uid'] : '';
+            if ($uid !== '') {
+                $uids[$uid] = true;
+            }
+        }
+
+        if (empty($uids)) {
+            return [];
+        }
+
+        $allowed = array_fill_keys(array_keys($uids), true);
+        $db = new Aerosalloyalty_Model_Db_Table_WebhookLog();
+        $tableName = $db->info('name');
+
+        $limit = count($allowed) * 6;
+        $limit = max(50, $limit);
+        $limit = min(500, $limit);
+
+        $select = $db->select()
+            ->from($tableName)
+            ->where('value_id = ?', (int)$valueId)
+            ->order('created_at DESC')
+            ->limit($limit);
+
+        $rows = $db->fetchAll($select);
+        if (!$rows) {
+            return [];
+        }
+
+        $results = [];
+
+        foreach ($rows as $row) {
+            if ($row instanceof Zend_Db_Table_Row_Abstract) {
+                $row = $row->toArray();
+            }
+
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $candidateUids = $this->_resolveCampaignUidsFromPayload($row['payload'] ?? '', $allowed);
+            if (empty($candidateUids)) {
+                continue;
+            }
+
+            $entry = [
+                'direction' => isset($row['direction']) ? (string)$row['direction'] : null,
+                'http_status' => array_key_exists('http_status', $row) && $row['http_status'] !== null
+                    ? (int)$row['http_status']
+                    : null,
+                'endpoint' => isset($row['endpoint']) ? (string)$row['endpoint'] : null,
+                'created_at' => isset($row['created_at']) ? (string)$row['created_at'] : null,
+            ];
+
+            foreach ($candidateUids as $uid) {
+                if (!isset($allowed[$uid])) {
+                    continue;
+                }
+
+                if (!isset($results[$uid]['latest'])) {
+                    $results[$uid]['latest'] = $entry;
+                }
+
+                $direction = $entry['direction'] ?: '';
+                if ($direction && !isset($results[$uid][$direction])) {
+                    $results[$uid][$direction] = $entry;
+                }
+            }
+        }
+
+        foreach ($results as $uid => &$data) {
+            if (!isset($data['latest'])) {
+                if (isset($data['outbound'])) {
+                    $data['latest'] = $data['outbound'];
+                } elseif (isset($data['inbound'])) {
+                    $data['latest'] = $data['inbound'];
+                }
+            }
+
+            $data['summary'] = $this->_composeLogSummary($data);
+        }
+        unset($data);
+
+        return $results;
+    }
+
+    /**
+     * Extract campaign UIDs referenced within a webhook log payload.
+     *
+     * @param string $payloadRaw
+     * @param array  $allowed
+     * @return array
+     */
+    protected function _resolveCampaignUidsFromPayload($payloadRaw, array $allowed)
+    {
+        $matches = [];
+
+        if (is_string($payloadRaw) && $payloadRaw !== '') {
+            $decoded = json_decode($payloadRaw, true);
+
+            if (is_array($decoded)) {
+                $paths = [
+                    ['campaign', 'campaign_uid'],
+                    ['campaign', 'uid'],
+                    ['payload', 'campaign_uid'],
+                    ['payload', 'uid'],
+                    ['campaign_uid'],
+                    ['uid'],
+                ];
+
+                foreach ($paths as $path) {
+                    $value = $decoded;
+                    foreach ($path as $segment) {
+                        if (!is_array($value) || !array_key_exists($segment, $value)) {
+                            $value = null;
+                            break;
+                        }
+                        $value = $value[$segment];
+                    }
+
+                    if ($value !== null && $value !== '') {
+                        if (is_scalar($value)) {
+                            $matches[(string)$value] = true;
+                        }
+                    }
+                }
+            }
+
+            if (empty($matches)) {
+                foreach ($allowed as $uid => $flag) {
+                    if (strpos($payloadRaw, (string)$uid) !== false) {
+                        $matches[(string)$uid] = true;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_filter(array_keys($matches), function ($uid) use ($allowed) {
+            return isset($allowed[$uid]);
+        }));
+    }
+
+    /**
+     * Compose human readable summary from captured log data.
+     *
+     * @param array $data
+     * @return string|null
+     */
+    protected function _composeLogSummary(array $data)
+    {
+        $parts = [];
+
+        if (isset($data['inbound'])) {
+            $parts[] = $this->_formatLogLine($data['inbound']);
+        }
+
+        if (isset($data['outbound'])) {
+            $parts[] = $this->_formatLogLine($data['outbound']);
+        }
+
+        if ($parts) {
+            return implode(' → ', $parts);
+        }
+
+        if (isset($data['latest'])) {
+            return $this->_formatLogLine($data['latest']);
+        }
+
+        return null;
+    }
+
+    /**
+     * Format a single log line fragment.
+     *
+     * @param array $log
+     * @return string
+     */
+    protected function _formatLogLine(array $log)
+    {
+        $direction = isset($log['direction']) ? (string)$log['direction'] : '';
+        $directionLabel = $direction === 'outbound'
+            ? p__('Aerosalloyalty', 'Outbound')
+            : p__('Aerosalloyalty', 'Inbound');
+
+        $statusLabel = isset($log['http_status']) && $log['http_status'] !== null
+            ? (string)$log['http_status']
+            : p__('Aerosalloyalty', 'N/A');
+
+        $timestamp = isset($log['created_at']) && $log['created_at']
+            ? (string)$log['created_at']
+            : p__('Aerosalloyalty', 'Unknown time');
+
+        return sprintf('%s (%s) · %s', $directionLabel, $statusLabel, $timestamp);
     }
 
     /** CAMPAIGN — delete (POST by value_id, card_number, campaign_uid) */

--- a/resources/design/desktop/flat/template/aerosalloyalty/application/edit.phtml
+++ b/resources/design/desktop/flat/template/aerosalloyalty/application/edit.phtml
@@ -257,6 +257,7 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
                 <th><?php echo p__("Aerosalloyalty", "Name"); ?></th>
                 <th><?php echo p__("Aerosalloyalty", "Points"); ?></th>
                 <th><?php echo p__("Aerosalloyalty", "Prizes"); ?></th>
+                <th><?php echo p__("Aerosalloyalty", "Logs"); ?></th>
                 <th><?php echo p__("Aerosalloyalty", "Action"); ?></th>
               </tr>
             </thead>
@@ -686,6 +687,32 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
         $('<td/>').text(c.name || '').appendTo($tr);
         $('<td/>').text(parseInt(c.points_balance || 0, 10)).appendTo($tr);
         $('<td/>').text(c.prizes || '').appendTo($tr);
+
+        var logs = c.webhook_logs || {};
+        var summary = c.webhook_log_summary || '';
+        var latest = logs.latest || null;
+        var tooltipParts = [];
+        if (logs.inbound) {
+          tooltipParts.push((logs.inbound.direction || 'inbound') + ' ' + (logs.inbound.http_status !== null ? logs.inbound.http_status : 'N/A') + ' @ ' + (logs.inbound.created_at || '')); 
+        }
+        if (logs.outbound) {
+          tooltipParts.push((logs.outbound.direction || 'outbound') + ' ' + (logs.outbound.http_status !== null ? logs.outbound.http_status : 'N/A') + ' @ ' + (logs.outbound.created_at || ''));
+        }
+        if (!tooltipParts.length && latest) {
+          tooltipParts.push((latest.direction || '') + ' ' + (latest.http_status !== null ? latest.http_status : 'N/A') + ' @ ' + (latest.created_at || ''));
+        }
+        var tooltip = tooltipParts.join(' \u2192 ');
+
+        var $logCell = $('<td/>');
+        if (summary) {
+          $('<span/>').text(summary).appendTo($logCell);
+        } else {
+          $('<span/>').text('<?php echo p__("Aerosalloyalty", "No logs yet"); ?>').appendTo($logCell);
+        }
+        if (tooltip) {
+          $logCell.attr('title', tooltip);
+        }
+        $logCell.appendTo($tr);
 
         var $actions = $('<td/>');
         var $del = $('<button type="button" class="btn btn-danger btn-xs"><i class="icon-trash"></i> <?php echo p__("", "Delete"); ?></button>');


### PR DESCRIPTION
## Summary
- fetch the latest webhook log metadata per campaign when loading admin listings
- expose formatted log summaries alongside raw inbound/outbound details in the API response
- surface a new Logs column in the admin table with summaries and tooltips

## Testing
- php -l controllers/ApplicationController.php

------
https://chatgpt.com/codex/tasks/task_e_68e175c981f0832a88ee8b1026710284