### PR TITLE
Update mobile webhook payload and documentation

### DIFF
--- a/resources/design/desktop/flat/template/aerosalloyalty/application/edit.phtml
+++ b/resources/design/desktop/flat/template/aerosalloyalty/application/edit.phtml
@@ -277,19 +277,22 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
           <p class="alert alert-info" ><?php echo p__('Aerosalloyalty', 'When a card is linked (via manual entry, scan, or virtual creation), the module sends a POST request to the configured Webhook URL.'); ?></p>
           <p class="alert alert-success"><b><?php echo p__('Aerosalloyalty', 'Method'); ?>:</b> POST</p>
           <p class="alert alert-info"><b><?php echo p__('Aerosalloyalty', 'Content-Type'); ?>:</b> application/json</p>
-          <p class="alert alert-danger"><b><?php echo p__('Aerosalloyalty', 'Event'); ?>:</b> <code>card_linked</code></p>
+          <p class="alert alert-danger"><b><?php echo p__('Aerosalloyalty', 'Event'); ?>:</b> <code>CardActivated</code></p>
           <p><b><?php echo p__('Aerosalloyalty', 'Payload'); ?>:</b></p>
           <pre style="white-space: pre-wrap; word-break: break-word; background:#f7f7f9; padding:12px; border-radius:6px;">
                     `{
-                      "value_id": 123,
-                      "card_number": "4006381333931",
-                      "customer": {
-                        "id": 456,
-                        "first_name": "John",
-                        "last_name": "Doe",
-                        "email": "john@example.com"
+                      "event": "CardActivated",
+                      "timestamp": "2024-01-01T12:34:56+00:00",
+                      "card": {
+                        "card_number": "4006381333931",
+                        "ean_encoding": "EAN13"
                       },
-                      "event": "card_linked"
+                      "user": {
+                        "name": "John",
+                        "surname": "Doe",
+                        "phone": "+33 1 23 45 67 89",
+                        "email": "john@example.com"
+                      }
                     }`
           </pre>
           <p class="alert alert-warning"><b><?php echo p__('Aerosalloyalty', 'Notes'); ?>:</b></p>


### PR DESCRIPTION
## Summary
- restructure the mobile webhook payload to include card encoding, timestamp, and mapped customer details
- resolve webhook URL tokens with card and user data while enriching the customer lookup with phone/name fallbacks
- refresh the admin webhook documentation to reflect the new outbound body

## Testing
- php -l controllers/Mobile/ViewController.php

------
https://chatgpt.com/codex/tasks/task_e_68e17c59cc5c832a874d480548898227