### PR TITLE
Guard benefits access behind toggle

### DIFF
--- a/features/aerosalloyalty/assets/templates/l1/main.html
+++ b/features/aerosalloyalty/assets/templates/l1/main.html
@@ -161,6 +161,7 @@
         <button
           class="button button-positive button-block"
           ng-click="openCampaigns()"
+          ng-if="enable_check_benefits"
           style="background-color: #6ba8ff; font-weight: bold"
         >
           {{ :: 'Check your points and benefits' | translate:'aerosalloyalty' }}
@@ -177,7 +178,7 @@
     </div>
 
     <!-- ===================== CAMPAIGNS ===================== -->
-    <div ng-if="state==='campaigns'">
+    <div ng-if="enable_check_benefits && state==='campaigns'">
       <h3 style="color: #2c3e50; font-weight: 600; margin-bottom: 15px">
         {{ :: 'Le tue raccolte e promozioni attive' | translate:'aerosalloyalty'
         }}

--- a/features/aerosalloyalty/js/controllers/aerosalloyalty.js
+++ b/features/aerosalloyalty/js/controllers/aerosalloyalty.js
@@ -11,6 +11,7 @@ angular.module("starter").controller(
     $scope.state = "loading";
     $scope.card = null;
     $scope.campaigns = [];
+    $scope.enable_check_benefits = true;
 
     $scope.value_id = $stateParams.value_id || null;
     $scope.is_logged_in = Customer.isLoggedIn();
@@ -52,6 +53,19 @@ angular.module("starter").controller(
 
     // Load campaigns/benefits for the current card
     $scope.openCampaigns = function () {
+      if (!$scope.enable_check_benefits) {
+        $ionicPopup
+          .alert({
+            title: 'Unavailable',
+            template: 'Checking points and benefits is currently disabled.',
+            okText: 'OK',
+            okType: 'button-balanced'
+          })
+          .then(function () {
+            $scope.state = $scope.card ? 'card' : 'setup';
+          });
+        return;
+      }
       if (!$scope.value_id || !$scope.customer_id) return alertMsg("Missing identifiers");
       loading(true);
       Aerosalloyalty.campaigns($scope.value_id, $scope.customer_id)
@@ -275,6 +289,19 @@ angular.module("starter").controller(
           if (d.error) throw d.message;
           if (d.settings && d.settings.default_ean_encoding)
             $scope.manual.ean_encoding = d.settings.default_ean_encoding;
+
+          if (d.settings && typeof d.settings.enable_check_benefits !== 'undefined') {
+            var enableFlag = d.settings.enable_check_benefits;
+            if (typeof enableFlag === 'string') {
+              var lowered = enableFlag.toLowerCase();
+              if (lowered === 'false' || lowered === '0') {
+                enableFlag = false;
+              } else if (lowered === 'true' || lowered === '1') {
+                enableFlag = true;
+              }
+            }
+            $scope.enable_check_benefits = !!enableFlag;
+          }
 
           if (d.card) {
             $scope.card = d.card;


### PR DESCRIPTION
## Summary
- capture the enable_check_benefits flag during initialization and expose it on the scope
- block the campaigns flow when the flag is disabled and keep the UI in the card/setup states
- hide the "Check your points and benefits" entry points when campaigns are disabled

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e17f061a0c832aa270077724360e41