### PR TITLE
Rename campaign prizes field to prizes_to_redeem

### DIFF
--- a/controllers/ApplicationController.php
+++ b/controllers/ApplicationController.php
@@ -32,6 +32,18 @@ class Aerosalloyalty_ApplicationController extends Application_Controller_Defaul
                 $data = [];
             }
 
+            if (!array_key_exists('prizes_to_redeem', $data) && array_key_exists('prizes', $data)) {
+                $data['prizes_to_redeem'] = $data['prizes'];
+            }
+
+            if (!array_key_exists('prizes_to_redeem', $data)) {
+                $data['prizes_to_redeem'] = null;
+            }
+
+            if (array_key_exists('prizes', $data)) {
+                unset($data['prizes']);
+            }
+
             if (!array_key_exists('last_operation', $data)) {
                 $data['last_operation'] = null;
             }

--- a/controllers/Mobile/ViewController.php
+++ b/controllers/Mobile/ViewController.php
@@ -480,6 +480,15 @@ class Aerosalloyalty_Mobile_ViewController extends Application_Controller_Mobile
             $list = [];
             foreach ($rows as $c) {
                 $d = $c->getData();
+                if (!array_key_exists('prizes_to_redeem', $d) && array_key_exists('prizes', $d)) {
+                    $d['prizes_to_redeem'] = $d['prizes'];
+                }
+                if (!array_key_exists('prizes_to_redeem', $d)) {
+                    $d['prizes_to_redeem'] = null;
+                }
+                if (array_key_exists('prizes', $d)) {
+                    unset($d['prizes']);
+                }
                 $code = $d['campaign_type_code'] ?? '';
                 $d['campaign_type_name'] = isset($map[$code]) ? $map[$code]['name'] : $code;
                 $d['campaign_type_icon'] = isset($map[$code]) ? $map[$code]['icon'] : null;

--- a/controllers/Public/CampaignController.php
+++ b/controllers/Public/CampaignController.php
@@ -67,6 +67,55 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
         }
     }
 
+    protected function resolvePrizesToRedeem(array $body, $default = null)
+    {
+        $params = $this->getRequest()->getParams();
+        $sources = [
+            ['params', 'prizes_to_redeem'],
+            ['body', 'prizes_to_redeem'],
+            ['params', 'prizes'],
+            ['body', 'prizes'],
+        ];
+
+        foreach ($sources as [$type, $key]) {
+            if ($type === 'params') {
+                if (!array_key_exists($key, $params)) {
+                    continue;
+                }
+                $value = $params[$key];
+            } else {
+                if (!array_key_exists($key, $body)) {
+                    continue;
+                }
+                $value = $body[$key];
+            }
+
+            if ($value === null) {
+                return null;
+            }
+
+            if (!is_scalar($value)) {
+                return null;
+            }
+
+            $value = trim((string)$value);
+            return $value !== '' ? $value : null;
+        }
+
+        if ($default === null) {
+            return null;
+        }
+
+        if (!is_scalar($default)) {
+            return null;
+        }
+
+        $default = (string)$default;
+        $default = trim($default);
+
+        return $default !== '' ? $default : null;
+    }
+
     public function postAction()
     {
         $valueId = null;
@@ -111,8 +160,7 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
             $points = $this->getRequest()->getParam('points_balance', $body['points_balance'] ?? 0);
             $points = (int)$points;
 
-            $prizes = $this->getRequest()->getParam('prizes', $body['prizes'] ?? null);
-            $prizes = $prizes !== null ? (string)$prizes : null;
+            $prizesToRedeem = $this->resolvePrizesToRedeem($body);
 
             $this->safeLog($valueId, 'inbound', null, [
                 'method' => 'POST',
@@ -122,7 +170,7 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
                     'campaign_type_code' =>$typeCode,
                     'name'               =>$name,
                     'points_balance'     =>$points,
-                    'prizes'             =>$prizes,
+                    'prizes_to_redeem'   =>$prizesToRedeem,
                 ],
             ]);
 
@@ -135,7 +183,7 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
                 'campaign_type_code' => $typeCode,
                 'name'               => $name,
                 'points_balance'     => $points,
-                'prizes'             => $prizes,
+                'prizes_to_redeem'   => $prizesToRedeem,
             ]);
 
             $response = [
@@ -147,7 +195,7 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
                     'campaign_type_code' => $campaign->getCampaignTypeCode(),
                     'name'               => $campaign->getName(),
                     'points_balance'     => (int)$campaign->getPointsBalance(),
-                    'prizes'             => $campaign->getPrizes(),
+                    'prizes_to_redeem'   => $campaign->getPrizesToRedeem(),
                 ],
             ];
 
@@ -225,8 +273,7 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
             $points = $this->getRequest()->getParam('points_balance', $body['points_balance'] ?? $campaign->getPointsBalance());
             $points = (int)$points;
 
-            $prizes = $this->getRequest()->getParam('prizes', array_key_exists('prizes', $body) ? $body['prizes'] : $campaign->getPrizes());
-            $prizes = $prizes !== null ? (string)$prizes : null;
+            $prizesToRedeem = $this->resolvePrizesToRedeem($body, $campaign->getPrizesToRedeem());
 
             $this->safeLog($valueId, 'inbound', null, [
                 'method' => 'PUT',
@@ -237,7 +284,7 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
                     'campaign_type_code' => $typeCode,
                     'name'               => $name,
                     'points_balance'     => $points,
-                    'prizes'             => $prizes,
+                    'prizes_to_redeem'   => $prizesToRedeem,
                 ],
             ]);
 
@@ -248,7 +295,7 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
                 'campaign_type_code' => $typeCode,
                 'name'               => $name,
                 'points_balance'     => $points,
-                'prizes'             => $prizes,
+                'prizes_to_redeem'   => $prizesToRedeem,
             ]);
 
             $response = [
@@ -260,7 +307,7 @@ class Aerosalloyalty_Public_CampaignController extends Application_Controller_De
                     'campaign_type_code' => $campaign->getCampaignTypeCode(),
                     'name'               => $campaign->getName(),
                     'points_balance'     => (int)$campaign->getPointsBalance(),
-                    'prizes'             => $campaign->getPrizes(),
+                    'prizes_to_redeem'   => $campaign->getPrizesToRedeem(),
                 ],
             ];
 

--- a/features/aerosalloyalty/assets/templates/l1/main.html
+++ b/features/aerosalloyalty/assets/templates/l1/main.html
@@ -219,9 +219,9 @@
             <b>{{ :: 'Nome Campagna:' | translate:'aerosalloyalty' }}</b> {{
             c.name }}
           </div>
-          <div class="item item-text-wrap" ng-if="c.prizes">
+          <div class="item item-text-wrap" ng-if="c.prizes_to_redeem || c.prizes">
             <b>{{ :: 'Premi da ritirare:' | translate:'aerosalloyalty' }}</b> {{
-            c.prizes }}
+            c.prizes_to_redeem || c.prizes }}
           </div>
         </div>
       </div>

--- a/init.php
+++ b/init.php
@@ -1,3 +1,23 @@
 <?php
 
-$init = function ($bootstrap) {};
+$init = function ($bootstrap) {
+    try {
+        $db = Zend_Db_Table::getDefaultAdapter();
+    } catch (Exception $e) {
+        return;
+    }
+
+    try {
+        $columns = $db->describeTable('aerosalloyalty_campaigns');
+    } catch (Exception $e) {
+        return;
+    }
+
+    if (isset($columns['prizes']) && !isset($columns['prizes_to_redeem'])) {
+        try {
+            $db->query('ALTER TABLE `aerosalloyalty_campaigns` CHANGE `prizes` `prizes_to_redeem` VARCHAR(255) NULL DEFAULT NULL');
+        } catch (Exception $e) {
+            // Ignore migration failure to avoid blocking init; admin can rerun manually.
+        }
+    }
+};

--- a/resources/db/schema/aerosalloyalty_campaigns.php
+++ b/resources/db/schema/aerosalloyalty_campaigns.php
@@ -29,7 +29,7 @@ $schemas['aerosalloyalty_campaigns'] = [
         'type' => 'int(11)',
         'default' => '0'
     ],
-    'prizes' => [
+    'prizes_to_redeem' => [
         'type' => 'varchar(255)',
         'is_null' => true,
         'default' => null

--- a/resources/design/desktop/flat/template/aerosalloyalty/application/edit.phtml
+++ b/resources/design/desktop/flat/template/aerosalloyalty/application/edit.phtml
@@ -321,12 +321,12 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
           <ul>
             <li>
               <code>https://module.zeltacode.com/aerosalloyalty/public_campaign/post?app_id={APP_ID}&card_number={CARD_NUMBER}</code><br>
-              <?php echo p__('Aerosalloyalty', 'Body (JSON): {"campaign_type_code":"promo","name":"Back to School","points_balance":120,"prizes":"T-shirt"}'); ?><br>
+              <?php echo p__('Aerosalloyalty', 'Body (JSON): {"campaign_type_code":"promo","name":"Back to School","points_balance":120,"prizes_to_redeem":"T-shirt"}'); ?><br>
               <?php echo p__('Aerosalloyalty', 'Response: 201 Created with the persisted campaign (server assigns campaign_uid).'); ?>
             </li>
             <li class="mt-3">
               <code>https://module.zeltacode.com/aerosalloyalty/public_campaign/put/{UID}?app_id={APP_ID}&card_number={CARD_NUMBER}</code><br>
-              <?php echo p__('Aerosalloyalty', 'Body (JSON): provide any updatable fields (campaign_type_code, name, points_balance, prizes).'); ?><br>
+              <?php echo p__('Aerosalloyalty', 'Body (JSON): provide any updatable fields (campaign_type_code, name, points_balance, prizes_to_redeem).'); ?><br>
               <?php echo p__('Aerosalloyalty', 'Response: 200 OK with the refreshed campaign payload.'); ?>
             </li>
             <li class="mt-3">
@@ -769,7 +769,13 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
         $('<td/>').text(c.campaign_type_code || '').appendTo($tr);
         $('<td/>').text(c.name || '').appendTo($tr);
         $('<td/>').text(parseInt(c.points_balance || 0, 10)).appendTo($tr);
-        $('<td/>').text(c.prizes || '').appendTo($tr);
+        var prizes = '';
+        if (c.prizes_to_redeem !== undefined && c.prizes_to_redeem !== null) {
+          prizes = c.prizes_to_redeem;
+        } else if (c.prizes !== undefined && c.prizes !== null) {
+          prizes = c.prizes;
+        }
+        $('<td/>').text(prizes || '').appendTo($tr);
 
         var logs = c.webhook_logs || {};
         var summary = c.webhook_log_summary || '';


### PR DESCRIPTION
## Summary
- Update the public campaign API to accept and return the `prizes_to_redeem` field
- Normalize campaign persistence and schema to use `prizes_to_redeem` while migrating existing data
- Refresh admin and mobile serializers/UI to surface the renamed field with fallbacks

## Testing
- php -l controllers/Public/CampaignController.php
- php -l Model/Campaign.php
- php -l controllers/ApplicationController.php
- php -l controllers/Mobile/ViewController.php
- php -l init.php

------
https://chatgpt.com/codex/tasks/task_e_68e1855e6154832a9f97a482dcaff803